### PR TITLE
feat: add stored cookie request matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ final setCookie = Cookie.fromString(
 );
 print(setCookie.path); // /
 
+final stored = StoredCookie.fromSetCookie(
+  'sid=abc; Path=/; HttpOnly',
+  requestUri: Uri.parse('https://example.com/login'),
+);
+print(stored.matches(Uri.parse('https://example.com/profile'))); // true
+print(stored.toRequestCookie()); // sid=abc
+
 final values = Cookie.splitSetCookie(
   'a=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT, c=d; Path=/',
 );
@@ -40,6 +47,7 @@ print(values); // [a=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT, c=d; Path=/]
 - `Cookie.parse` - Parse client-side `cookie` header map.
 - `Cookie.fromString` - Parse a set-cookie string to Cookie instance.
 - `Cookie.splitSetCookie` - Split a string of multiple set-cookie values into a set-cookie string list.
+- `StoredCookie.fromSetCookie` - Normalize a Set-Cookie value for request matching.
 
 ## CopyWith And Clear
 

--- a/lib/ocookie.dart
+++ b/lib/ocookie.dart
@@ -1,2 +1,3 @@
 export 'src/cookie.dart';
+export 'src/stored_cookie.dart';
 export 'src/types.dart';

--- a/lib/src/stored_cookie.dart
+++ b/lib/src/stored_cookie.dart
@@ -58,6 +58,13 @@ final class StoredCookie {
 
     final hostOnly = !hasDomainAttribute;
     final domain = hostOnly ? requestHost : _normalizeDomain(rawDomain);
+    if (cookie.secure && requestUri.scheme != 'https') {
+      throw ArgumentError.value(
+        requestUri,
+        'requestUri',
+        'Secure cookies can only be stored from secure request URIs.',
+      );
+    }
     if (!hostOnly && !_isValidCookieDomain(requestHost, domain)) {
       throw ArgumentError.value(
         cookie.domain,
@@ -130,12 +137,16 @@ String _requestHost(Uri uri) {
     throw ArgumentError.value(uri, 'uri', 'URI must include a host.');
   }
 
-  return uri.host.toLowerCase();
+  return _stripTrailingDot(uri.host.toLowerCase());
 }
 
 String _normalizeDomain(String value) {
-  final normalized = value.trim().toLowerCase();
+  final normalized = _stripTrailingDot(value.trim().toLowerCase());
   return normalized.startsWith('.') ? normalized.substring(1) : normalized;
+}
+
+String _stripTrailingDot(String value) {
+  return value.endsWith('.') ? value.substring(0, value.length - 1) : value;
 }
 
 bool _isValidCookieDomain(String requestHost, String domain) {

--- a/lib/src/stored_cookie.dart
+++ b/lib/src/stored_cookie.dart
@@ -1,0 +1,210 @@
+import 'cookie.dart';
+import 'types.dart';
+
+/// A normalized cookie entry for client-side request matching.
+///
+/// [Cookie] represents the parsed Set-Cookie value. [StoredCookie] adds the
+/// user-agent state needed to decide whether that cookie should be sent with a
+/// later request.
+final class StoredCookie {
+  const StoredCookie._({
+    required this.cookie,
+    required this.domain,
+    required this.path,
+    required this.hostOnly,
+    required this.expiresAt,
+  });
+
+  /// The parsed cookie with normalized Domain and Path attributes.
+  final Cookie cookie;
+
+  /// The normalized domain used for request matching.
+  final String domain;
+
+  /// The effective path used for request matching.
+  final String path;
+
+  /// Whether the cookie omitted a Domain attribute and is bound to one host.
+  final bool hostOnly;
+
+  /// The absolute expiry time after applying Max-Age precedence.
+  ///
+  /// A null value represents a session cookie.
+  final DateTime? expiresAt;
+
+  /// Parses and normalizes a Set-Cookie value received for [requestUri].
+  factory StoredCookie.fromSetCookie(
+    String setCookie, {
+    required Uri requestUri,
+    DateTime? now,
+    CookieCodec? decode,
+  }) {
+    return StoredCookie.fromCookie(
+      Cookie.fromString(setCookie, decode: decode),
+      requestUri: requestUri,
+      now: now,
+    );
+  }
+
+  /// Normalizes [cookie] as if it was received for [requestUri].
+  factory StoredCookie.fromCookie(
+    Cookie cookie, {
+    required Uri requestUri,
+    DateTime? now,
+  }) {
+    final requestHost = _requestHost(requestUri);
+    final rawDomain = cookie.domain?.trim();
+    final hasDomainAttribute = rawDomain != null && rawDomain.isNotEmpty;
+
+    final hostOnly = !hasDomainAttribute;
+    final domain = hostOnly ? requestHost : _normalizeDomain(rawDomain);
+    if (!hostOnly && !_isValidCookieDomain(requestHost, domain)) {
+      throw ArgumentError.value(
+        cookie.domain,
+        'cookie.domain',
+        'Cookie domain does not match request host.',
+      );
+    }
+
+    final path = _effectivePath(cookie.path, requestUri.path);
+    final expiresAt = _expiresAt(cookie, now ?? DateTime.now().toUtc());
+    final normalizedCookie = hostOnly
+        ? cookie.copyWith(
+            path: path,
+            clear: const <CookieNullableField>{CookieNullableField.domain},
+          )
+        : cookie.copyWith(domain: domain, path: path);
+
+    return StoredCookie._(
+      cookie: normalizedCookie,
+      domain: domain,
+      path: path,
+      hostOnly: hostOnly,
+      expiresAt: expiresAt,
+    );
+  }
+
+  /// Whether this cookie is expired at [now].
+  bool isExpired(DateTime now) {
+    final expiresAt = this.expiresAt;
+    return expiresAt != null && !expiresAt.isAfter(now.toUtc());
+  }
+
+  /// Whether this cookie should be sent with a request to [uri].
+  ///
+  /// If [now] is supplied, expired cookies do not match.
+  bool matches(Uri uri, {DateTime? now}) {
+    if (now != null && isExpired(now)) {
+      return false;
+    }
+
+    final requestHost = _requestHost(uri);
+    if (hostOnly) {
+      if (requestHost != domain) {
+        return false;
+      }
+    } else if (!_domainMatches(requestHost, domain)) {
+      return false;
+    }
+
+    final requestPath = uri.path.isEmpty ? '/' : uri.path;
+    if (!_pathMatches(requestPath, path)) {
+      return false;
+    }
+
+    if (cookie.secure && uri.scheme != 'https') {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Serializes the cookie as a Cookie request header pair.
+  String toRequestCookie({CookieCodec? encode}) {
+    return Cookie(cookie.name, cookie.value).serialize(encode: encode);
+  }
+}
+
+String _requestHost(Uri uri) {
+  if (uri.host.isEmpty) {
+    throw ArgumentError.value(uri, 'uri', 'URI must include a host.');
+  }
+
+  return uri.host.toLowerCase();
+}
+
+String _normalizeDomain(String value) {
+  final normalized = value.trim().toLowerCase();
+  return normalized.startsWith('.') ? normalized.substring(1) : normalized;
+}
+
+bool _isValidCookieDomain(String requestHost, String domain) {
+  return domain.contains('.') &&
+      !_isIpAddress(domain) &&
+      _domainMatches(requestHost, domain);
+}
+
+bool _domainMatches(String requestHost, String domain) {
+  if (requestHost == domain) {
+    return true;
+  }
+  if (_isIpAddress(requestHost)) {
+    return false;
+  }
+
+  return requestHost.endsWith('.$domain');
+}
+
+bool _isIpAddress(String host) {
+  return _ipv4AddressPattern.hasMatch(host) || host.contains(':');
+}
+
+String _effectivePath(String? cookiePath, String requestPath) {
+  if (cookiePath == null || cookiePath.isEmpty || !cookiePath.startsWith('/')) {
+    return _defaultPath(requestPath);
+  }
+
+  return cookiePath;
+}
+
+String _defaultPath(String requestPath) {
+  if (requestPath.isEmpty || !requestPath.startsWith('/')) {
+    return '/';
+  }
+
+  final slashIndex = requestPath.lastIndexOf('/');
+  if (slashIndex <= 0) {
+    return '/';
+  }
+
+  return requestPath.substring(0, slashIndex);
+}
+
+bool _pathMatches(String requestPath, String cookiePath) {
+  if (requestPath == cookiePath) {
+    return true;
+  }
+  if (!requestPath.startsWith(cookiePath)) {
+    return false;
+  }
+  if (cookiePath.endsWith('/')) {
+    return true;
+  }
+
+  return requestPath[cookiePath.length] == '/';
+}
+
+DateTime? _expiresAt(Cookie cookie, DateTime now) {
+  final maxAge = cookie.maxAge;
+  if (maxAge != null) {
+    if (maxAge.inSeconds <= 0) {
+      return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+    }
+
+    return now.toUtc().add(maxAge);
+  }
+
+  return cookie.expires?.toUtc();
+}
+
+final _ipv4AddressPattern = RegExp(r'^\d{1,3}(?:\.\d{1,3}){3}$');

--- a/lib/src/stored_cookie.dart
+++ b/lib/src/stored_cookie.dart
@@ -65,6 +65,7 @@ final class StoredCookie {
         'Secure cookies can only be stored from secure request URIs.',
       );
     }
+    _validateCookieNamePrefix(cookie, requestUri, hostOnly);
     if (!hostOnly && !_isValidCookieDomain(requestHost, domain)) {
       throw ArgumentError.value(
         cookie.domain,
@@ -141,12 +142,35 @@ String _requestHost(Uri uri) {
 }
 
 String _normalizeDomain(String value) {
-  final normalized = _stripTrailingDot(value.trim().toLowerCase());
+  final normalized = value.trim().toLowerCase();
   return normalized.startsWith('.') ? normalized.substring(1) : normalized;
 }
 
 String _stripTrailingDot(String value) {
   return value.endsWith('.') ? value.substring(0, value.length - 1) : value;
+}
+
+void _validateCookieNamePrefix(Cookie cookie, Uri requestUri, bool hostOnly) {
+  if (cookie.name.startsWith('__Secure-') &&
+      (!cookie.secure || requestUri.scheme != 'https')) {
+    throw ArgumentError.value(
+      cookie.name,
+      'cookie.name',
+      '__Secure- cookies require Secure and a secure request URI.',
+    );
+  }
+
+  if (cookie.name.startsWith('__Host-') &&
+      (!cookie.secure ||
+          requestUri.scheme != 'https' ||
+          !hostOnly ||
+          cookie.path != '/')) {
+    throw ArgumentError.value(
+      cookie.name,
+      'cookie.name',
+      '__Host- cookies require Secure, Path=/, no Domain, and a secure request URI.',
+    );
+  }
 }
 
 bool _isValidCookieDomain(String requestHost, String domain) {

--- a/test/stored_cookie_test.dart
+++ b/test/stored_cookie_test.dart
@@ -25,8 +25,8 @@ void main() {
 
     test('normalizes domain attributes and matches subdomains', () {
       final stored = StoredCookie.fromSetCookie(
-        'sid=abc; Domain=.Example.COM; Path=/; Secure',
-        requestUri: Uri.parse('https://api.example.com/login'),
+        'sid=abc; Domain=.Example.COM.; Path=/; Secure',
+        requestUri: Uri.parse('https://api.example.com./login'),
       );
 
       expect(stored.cookie.domain, 'example.com');
@@ -44,6 +44,16 @@ void main() {
       expect(
         stored.matches(Uri.parse('http://example.com/profile')),
         isFalse,
+      );
+    });
+
+    test('rejects secure cookies from insecure request URIs', () {
+      expect(
+        () => StoredCookie.fromSetCookie(
+          'sid=abc; Secure',
+          requestUri: Uri.parse('http://example.com/login'),
+        ),
+        throwsArgumentError,
       );
     });
 

--- a/test/stored_cookie_test.dart
+++ b/test/stored_cookie_test.dart
@@ -25,7 +25,7 @@ void main() {
 
     test('normalizes domain attributes and matches subdomains', () {
       final stored = StoredCookie.fromSetCookie(
-        'sid=abc; Domain=.Example.COM.; Path=/; Secure',
+        'sid=abc; Domain=.Example.COM; Path=/; Secure',
         requestUri: Uri.parse('https://api.example.com./login'),
       );
 
@@ -47,6 +47,16 @@ void main() {
       );
     });
 
+    test('rejects domain attributes with trailing dots', () {
+      expect(
+        () => StoredCookie.fromSetCookie(
+          'sid=abc; Domain=example.com.',
+          requestUri: Uri.parse('https://example.com/login'),
+        ),
+        throwsArgumentError,
+      );
+    });
+
     test('rejects secure cookies from insecure request URIs', () {
       expect(
         () => StoredCookie.fromSetCookie(
@@ -55,6 +65,53 @@ void main() {
         ),
         throwsArgumentError,
       );
+    });
+
+    test('enforces __Secure- cookie-name prefix constraints', () {
+      expect(
+        () => StoredCookie.fromSetCookie(
+          '__Secure-sid=abc',
+          requestUri: Uri.parse('https://example.com/login'),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => StoredCookie.fromSetCookie(
+          '__Secure-sid=abc; Secure',
+          requestUri: Uri.parse('http://example.com/login'),
+        ),
+        throwsArgumentError,
+      );
+
+      final stored = StoredCookie.fromSetCookie(
+        '__Secure-sid=abc; Secure',
+        requestUri: Uri.parse('https://example.com/login'),
+      );
+      expect(stored.cookie.name, '__Secure-sid');
+    });
+
+    test('enforces __Host- cookie-name prefix constraints', () {
+      final valid = StoredCookie.fromSetCookie(
+        '__Host-sid=abc; Secure; Path=/',
+        requestUri: Uri.parse('https://example.com/login'),
+      );
+      expect(valid.hostOnly, isTrue);
+      expect(valid.path, '/');
+
+      for (final value in [
+        '__Host-sid=abc; Path=/',
+        '__Host-sid=abc; Secure',
+        '__Host-sid=abc; Secure; Path=/app',
+        '__Host-sid=abc; Secure; Path=/; Domain=example.com',
+      ]) {
+        expect(
+          () => StoredCookie.fromSetCookie(
+            value,
+            requestUri: Uri.parse('https://example.com/login'),
+          ),
+          throwsArgumentError,
+        );
+      }
     });
 
     test('rejects domain attributes outside the request host', () {

--- a/test/stored_cookie_test.dart
+++ b/test/stored_cookie_test.dart
@@ -1,0 +1,142 @@
+import 'package:ocookie/ocookie.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StoredCookie.fromSetCookie', () {
+    test('normalizes host-only cookies against the request host', () {
+      final stored = StoredCookie.fromSetCookie(
+        'sid=abc; HttpOnly',
+        requestUri: Uri.parse('https://example.com/login'),
+      );
+
+      expect(stored.cookie.name, 'sid');
+      expect(stored.cookie.value, 'abc');
+      expect(stored.cookie.domain, isNull);
+      expect(stored.domain, 'example.com');
+      expect(stored.path, '/');
+      expect(stored.hostOnly, isTrue);
+      expect(stored.expiresAt, isNull);
+      expect(stored.matches(Uri.parse('https://example.com/profile')), isTrue);
+      expect(
+        stored.matches(Uri.parse('https://sub.example.com/profile')),
+        isFalse,
+      );
+    });
+
+    test('normalizes domain attributes and matches subdomains', () {
+      final stored = StoredCookie.fromSetCookie(
+        'sid=abc; Domain=.Example.COM; Path=/; Secure',
+        requestUri: Uri.parse('https://api.example.com/login'),
+      );
+
+      expect(stored.cookie.domain, 'example.com');
+      expect(stored.domain, 'example.com');
+      expect(stored.hostOnly, isFalse);
+      expect(stored.matches(Uri.parse('https://example.com/profile')), isTrue);
+      expect(
+        stored.matches(Uri.parse('https://sub.example.com/profile')),
+        isTrue,
+      );
+      expect(
+        stored.matches(Uri.parse('https://other.example/profile')),
+        isFalse,
+      );
+      expect(
+        stored.matches(Uri.parse('http://example.com/profile')),
+        isFalse,
+      );
+    });
+
+    test('rejects domain attributes outside the request host', () {
+      expect(
+        () => StoredCookie.fromSetCookie(
+          'sid=abc; Domain=victim.example',
+          requestUri: Uri.parse('https://evil.example/login'),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects single-label and IP address domain attributes', () {
+      expect(
+        () => StoredCookie.fromSetCookie(
+          'sid=abc; Domain=com',
+          requestUri: Uri.parse('https://api.example.com/login'),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => StoredCookie.fromSetCookie(
+          'sid=abc; Domain=127.0.0.1',
+          requestUri: Uri.parse('http://127.0.0.1/login'),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('calculates the default path when Path is missing or invalid', () {
+      final missingPath = StoredCookie.fromSetCookie(
+        'sid=abc',
+        requestUri: Uri.parse('https://example.com/docs/index.html'),
+      );
+      final invalidPath = StoredCookie.fromSetCookie(
+        'sid=abc; Path=docs',
+        requestUri: Uri.parse('https://example.com/docs/index.html'),
+      );
+
+      expect(missingPath.path, '/docs');
+      expect(missingPath.cookie.path, '/docs');
+      expect(invalidPath.path, '/docs');
+      expect(invalidPath.cookie.path, '/docs');
+    });
+
+    test('applies path-match semantics', () {
+      final stored = StoredCookie.fromSetCookie(
+        'sid=abc; Path=/docs',
+        requestUri: Uri.parse('https://example.com/docs/index.html'),
+      );
+
+      expect(stored.matches(Uri.parse('https://example.com/docs')), isTrue);
+      expect(stored.matches(Uri.parse('https://example.com/docs/1')), isTrue);
+      expect(stored.matches(Uri.parse('https://example.com/docs2')), isFalse);
+    });
+
+    test('applies Max-Age precedence over Expires', () {
+      final now = DateTime.utc(2026, 1, 1, 0, 0);
+      final stored = StoredCookie.fromSetCookie(
+        'sid=abc; Max-Age=60; Expires=Wed, 21 Oct 2015 07:28:00 GMT',
+        requestUri: Uri.parse('https://example.com/login'),
+        now: now,
+      );
+
+      expect(stored.expiresAt, now.add(const Duration(seconds: 60)));
+      expect(stored.isExpired(now.add(const Duration(seconds: 59))), isFalse);
+      expect(stored.isExpired(now.add(const Duration(seconds: 60))), isTrue);
+    });
+
+    test('treats Max-Age less than or equal to zero as immediately expired',
+        () {
+      final now = DateTime.utc(2026, 1, 1, 0, 0);
+      final stored = StoredCookie.fromSetCookie(
+        'sid=abc; Max-Age=0',
+        requestUri: Uri.parse('https://example.com/login'),
+        now: now,
+      );
+
+      expect(stored.isExpired(now), isTrue);
+      expect(
+        stored.matches(Uri.parse('https://example.com/profile'), now: now),
+        isFalse,
+      );
+    });
+
+    test('serializes only the request cookie pair', () {
+      final stored = StoredCookie.fromSetCookie(
+        'sid=a b; Path=/; HttpOnly; Secure',
+        requestUri: Uri.parse('https://example.com/login'),
+      );
+
+      expect(stored.toRequestCookie(), 'sid=a%20b');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- add `StoredCookie` as a normalized client-side Set-Cookie representation
- track host-only state, normalized domain, effective path, and absolute expiry time
- implement request matching for domain, path, secure-only, and optional expiry checks
- document the new API and cover the RFC policy cases with tests

Closes #8.

## Scope

This intentionally stops at single-cookie normalization and matching. The in-memory jar work remains separate for #9.

## Validation

- `dart test && dart analyze`
- `dart pub publish --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cookie normalization and request-matching functionality supporting domain validation, path derivation, expiration handling, and secure flag requirements.
  * Enables conversion between Set-Cookie headers and HTTP request cookie formats.

* **Documentation**
  * Extended README with usage examples demonstrating cookie normalization workflows and request matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->