### PR TITLE
docs: improve package docs and pub score readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,151 @@
-# 🍪 Ocookie
+# Ocookie
 
-Cookie and Set-Cookie parser and serializer.
+Ocookie is a dependency-light HTTP cookie toolkit for Dart and Flutter. It
+parses `Cookie` request headers, parses and serializes `Set-Cookie` response
+values, splits combined `Set-Cookie` headers, and provides a small client-side
+cookie jar with pluggable storage.
 
-## Installation
+## What It Covers
 
-To install `ocookie` add the following to your `pubspec.yaml`
-```yaml
-dependencies:
-  ocookie: latest
-```
+- Request cookies: parse a `Cookie` header into name-value pairs.
+- Response cookies: parse and serialize individual `Set-Cookie` values.
+- Header compatibility: split combined `Set-Cookie` strings without breaking
+  `Expires` dates or quoted commas.
+- Client storage: normalize received cookies and build request `Cookie` headers
+  for later URIs.
+- Extension points: customize value encoding and plug in your own
+  `CookieStore`.
 
-Alternatively, you can run the following command:
+## Install
+
 ```bash
 dart pub add ocookie
 ```
 
-## Basic Usage
+```dart
+import 'package:ocookie/ocookie.dart';
+```
+
+## Choose the API
+
+| Task | API |
+| --- | --- |
+| Parse a request `Cookie` header | `Cookie.parse` |
+| Parse one response `Set-Cookie` value | `Cookie.fromString` |
+| Construct a `Set-Cookie` value | `Cookie(...).serialize()` |
+| Check serialization errors without throwing | `Cookie.validate` |
+| Split a combined `Set-Cookie` string | `Cookie.splitSetCookie` |
+| Normalize one received cookie for matching | `StoredCookie.fromSetCookie` |
+| Store response cookies and build request headers | `CookieJar` |
+| Persist cookies outside memory | `CookieStore` |
+
+## Parse Request Cookies
+
+Use `Cookie.parse` for the `Cookie` header sent from a client to a server.
 
 ```dart
-final cookie = Cookie('name', 'value');
-print(cookie.serialize()); // name=value
-print(Cookie.parse('a=b;b=c')); // {a: b, b: c}
+final cookies = Cookie.parse('sid=abc; theme=light');
 
-final setCookie = Cookie.fromString(
+print(cookies['sid']); // abc
+print(cookies['theme']); // light
+```
+
+Malformed segments and empty names are ignored. If the same name appears more
+than once, the first parsed value is kept.
+
+## Work With Set-Cookie
+
+Use `Cookie.fromString` when you receive one `Set-Cookie` value.
+
+```dart
+final cookie = Cookie.fromString(
   'sid=abc; Path=/; HttpOnly; Secure; SameSite=None',
 );
-print(setCookie.path); // /
 
-final stored = StoredCookie.fromSetCookie(
-  'sid=abc; Path=/; HttpOnly',
-  requestUri: Uri.parse('https://example.com/login'),
+print(cookie.name); // sid
+print(cookie.value); // abc
+print(cookie.path); // /
+print(cookie.httpOnly); // true
+```
+
+Use `Cookie` and `serialize` when you need to create a `Set-Cookie` value.
+
+```dart
+final cookie = Cookie(
+  'sid',
+  'abc',
+  maxAge: const Duration(hours: 1),
+  path: '/',
+  httpOnly: true,
+  secure: true,
+  sameSite: CookieSameSite.lax,
 );
-print(stored.matches(Uri.parse('https://example.com/profile'))); // true
-print(stored.toRequestCookie()); // sid=abc
 
-final jar = CookieJar();
-await jar.save(
-  Uri.parse('https://example.com/login'),
-  ['sid=abc; Path=/; HttpOnly'],
-);
-print(await jar.header(Uri.parse('https://example.com/profile'))); // sid=abc
+final headerValue = cookie.serialize();
+print(headerValue);
+// sid=abc; Max-Age=3600; Path=/; HttpOnly; Secure; SameSite=Lax
+```
 
+Supported attributes include `Expires`, `Max-Age`, `Domain`, `Path`,
+`HttpOnly`, `Secure`, `Priority`, `SameSite`, and `Partitioned`.
+
+`serialize` validates cookie-safe characters and security constraints. For
+example, `SameSite=None` and `Partitioned` both require `Secure`.
+
+## Split Combined Set-Cookie Values
+
+Some HTTP clients expose multiple `Set-Cookie` headers as one string. Splitting
+on every comma is incorrect because `Expires` dates and quoted values can also
+contain commas.
+
+```dart
 final values = Cookie.splitSetCookie(
   'a=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT, c=d; Path=/',
 );
-print(values); // [a=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT, c=d; Path=/]
+
+print(values.length); // 2
+print(values.first); // a=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT
+print(values.last); // c=d; Path=/
 ```
 
-### Utils
+## Store and Send Cookies
 
-- `Cookie.serialize` - Serialize a cookie instance to string.
-- `Cookie.validate` - Validate a cookie and return all errors.
-- `Cookie.parse` - Parse client-side `cookie` header map.
-- `Cookie.fromString` - Parse a set-cookie string to Cookie instance.
-- `Cookie.splitSetCookie` - Split a string of multiple set-cookie values into a set-cookie string list.
-- `StoredCookie.fromSetCookie` - Normalize a Set-Cookie value for request matching.
-- `CookieJar` - Save Set-Cookie values and build matching Cookie request headers.
-- `CookieStore` - Plug in custom persistence behind the jar policy layer.
-
-## CopyWith And Clear
+`CookieJar` is the high-level client API. Save response cookies with the URI
+that produced them, then ask the jar for the `Cookie` request header for a later
+URI.
 
 ```dart
-final original = Cookie(
-  'sid',
-  'abc',
-  path: '/demo',
-  secure: true,
-  sameSite: CookieSameSite.none,
+final jar = CookieJar();
+final now = DateTime.utc(2026, 1, 1);
+
+await jar.save(
+  Uri.parse('https://example.com/login'),
+  [
+    'sid=abc; Path=/; HttpOnly',
+    'theme=dark; Path=/account',
+  ],
+  now: now,
 );
 
-final updated = original.copyWith(path: '/next');
-final cleared = original.copyWith(
-  clear: {CookieNullableField.path},
+final header = await jar.header(
+  Uri.parse('https://example.com/account/settings'),
+  now: now,
 );
+
+print(header); // theme=dark; sid=abc
 ```
 
-## Validation
+The jar applies host-only and domain matching, path matching, expiry handling,
+secure-cookie matching, `__Secure-` and `__Host-` prefix constraints, and
+request-header ordering by path length and creation time.
+
+The default store is `MemoryCookieStore`. Provide a custom `CookieStore` when
+cookies need to live in a database, file, secure storage, or another process.
+
+## Validate Before Serializing
+
+Use `validate` when you want all serialization problems at once instead of the
+first exception from `serialize`.
 
 ```dart
 final cookie = Cookie(
@@ -90,19 +160,54 @@ if (errors.isNotEmpty) {
 }
 ```
 
-## Security Constraints
+## Update Cookies
 
-- `SameSite=None` requires `Secure=true`.
-- `Partitioned=true` requires `Secure=true`.
+Use `copyWith` to adjust a cookie while preserving the rest of its attributes.
+Nullable attributes can be removed explicitly with `clear`.
 
-## Flag Semantics
+```dart
+final original = Cookie(
+  'sid',
+  'abc',
+  path: '/demo',
+  secure: true,
+);
 
-- `HttpOnly`, `Secure`, and `Partitioned` are two-state flags.
-- Omitting a flag is equivalent to setting it to `false`.
+final moved = original.copyWith(path: '/next');
+final withoutPath = original.copyWith(
+  clear: {CookieNullableField.path},
+);
+```
 
-# API Reference
+## Custom Encoding
 
-See the [API documentation](https://pub.dev/documentation/ocookie) for detailed information about all available APIs.
+Cookie values are URI component encoded by default. Pass custom codecs when an
+application already stores cookie-safe values or uses a different escaping
+scheme.
+
+```dart
+final serialized = Cookie(
+  'token',
+  'abc',
+).serialize(encode: (value) => value.toUpperCase());
+
+final parsed = Cookie.parse(
+  'token=ABC',
+  decode: (value) => value.toLowerCase(),
+);
+
+print(serialized); // token=ABC
+print(parsed['token']); // abc
+```
+
+## Example
+
+The runnable package example is in [`example/main.dart`](example/main.dart).
+
+## API Reference
+
+See the [API documentation](https://pub.dev/documentation/ocookie) for the full
+public API.
 
 ## License
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,46 @@
+import 'package:ocookie/ocookie.dart';
+
+Future<void> main() async {
+  final requestCookies = Cookie.parse('sid=abc; theme=light');
+  assert(requestCookies['sid'] == 'abc');
+  assert(requestCookies['theme'] == 'light');
+
+  final setCookie = Cookie(
+    'sid',
+    'abc',
+    maxAge: const Duration(hours: 1),
+    path: '/',
+    httpOnly: true,
+    secure: true,
+    sameSite: CookieSameSite.lax,
+  );
+  assert(
+    setCookie.serialize() ==
+        'sid=abc; Max-Age=3600; Path=/; HttpOnly; Secure; SameSite=Lax',
+  );
+
+  final parsedSetCookie = Cookie.fromString(
+    'theme=dark; Path=/account; HttpOnly',
+  );
+  assert(parsedSetCookie.name == 'theme');
+  assert(parsedSetCookie.path == '/account');
+  assert(parsedSetCookie.httpOnly);
+
+  final jar = CookieJar();
+  final receivedAt = DateTime.utc(2026, 1, 1);
+  final setCookieValues = Cookie.splitSetCookie(
+    'sid=abc; Path=/; HttpOnly, theme=dark; Path=/account',
+  );
+
+  await jar.save(
+    Uri.parse('https://example.com/login'),
+    setCookieValues,
+    now: receivedAt,
+  );
+
+  final header = await jar.header(
+    Uri.parse('https://example.com/account/settings'),
+    now: receivedAt,
+  );
+  assert(header == 'theme=dark; sid=abc');
+}

--- a/lib/ocookie.dart
+++ b/lib/ocookie.dart
@@ -1,3 +1,10 @@
+/// HTTP cookie parsing, serialization, and jar utilities.
+///
+/// Import this library to parse `Cookie` request headers, parse or construct
+/// `Set-Cookie` response values, normalize received cookies, and build
+/// `Cookie` request headers for later requests.
+library;
+
 export 'src/cookie.dart';
 export 'src/cookie_jar.dart';
 export 'src/cookie_key.dart';

--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -1,46 +1,106 @@
+/// @docImport 'cookie_jar.dart';
+/// @docImport 'stored_cookie.dart';
+library;
+
 import 'package:http_parser/http_parser.dart'
     show formatHttpDate, parseHttpDate;
 
 import '_utils.dart';
 import 'types.dart';
 
-/// Enum representing the priority levels for a cookie.
+/// Priority hints that can be attached to a `Set-Cookie` value.
+///
+/// Cookie priority is a non-standard but widely implemented attribute used by
+/// some user agents when deciding which cookies to evict first under storage
+/// pressure.
 enum CookiePriority {
-  /// Low priority.
+  /// A low-priority cookie.
   low,
 
-  /// Medium priority.
+  /// A medium-priority cookie.
   medium,
 
-  /// High priority.
+  /// A high-priority cookie.
   high
 }
 
-/// Enum representing the SameSite attribute for a cookie.
+/// Cross-site availability for a cookie.
+///
+/// The value maps to the `SameSite` attribute on a `Set-Cookie` header. A
+/// [none] value can only be serialized when [Cookie.secure] is true.
 enum CookieSameSite {
-  /// Lax same site enforcement.
+  /// Sends the cookie on same-site requests and top-level cross-site
+  /// navigations.
   lax,
 
-  /// Strict same site enforcement.
+  /// Sends the cookie only on same-site requests.
   strict,
 
-  /// No same site enforcement.
+  /// Sends the cookie on same-site and cross-site requests.
+  ///
+  /// Cookies using this value must also set [Cookie.secure].
   none
 }
 
-/// Nullable fields supported by [Cookie.copyWith.clear].
+/// Nullable `Set-Cookie` attributes supported by [Cookie.copyWith].
+///
+/// These values are used with the `clear` argument to remove an attribute from
+/// a copied [Cookie]. Boolean flags such as [Cookie.httpOnly] are not nullable;
+/// set them to false instead of clearing them.
 enum CookieNullableField {
+  /// Clears [Cookie.expires].
   expires,
+
+  /// Clears [Cookie.domain].
   domain,
+
+  /// Clears [Cookie.maxAge].
   maxAge,
+
+  /// Clears [Cookie.path].
   path,
+
+  /// Clears [Cookie.priority].
   priority,
+
+  /// Clears [Cookie.sameSite].
   sameSite,
 }
 
+/// Representation of one HTTP cookie.
+///
+/// A `Cookie` request header only carries name-value pairs. A `Set-Cookie`
+/// response header can also carry attributes such as `Path`, `Domain`,
+/// `HttpOnly`, `Secure`, and `SameSite`. This class stores both forms: use
+/// [parse] for a request header, [fromString] for a single `Set-Cookie` value,
+/// and [serialize] when constructing a response header value.
+///
+/// The constructor does not validate [name], [value], or attributes. Validation
+/// happens in [validate] and [serialize], after the value has been passed
+/// through the selected [CookieCodec].
+///
+/// ```dart
+/// final headerValue = Cookie(
+///   'sid',
+///   'abc',
+///   path: '/',
+///   httpOnly: true,
+///   secure: true,
+/// ).serialize();
+/// ```
+///
+/// This class does not decide whether a cookie should be sent to a later
+/// request. Use [StoredCookie] or [CookieJar] for domain, path, secure, expiry,
+/// and prefix matching.
 class Cookie {
   static const Set<CookieNullableField> _noClearedFields = {};
 
+  /// Creates a cookie with [name], [value], and optional `Set-Cookie`
+  /// attributes.
+  ///
+  /// The [httpOnly], [secure], and [partitioned] flags default to false. This
+  /// means that omitted flags and explicitly false flags have the same
+  /// serialized behavior.
   const Cookie(
     this.name,
     this.value, {
@@ -55,18 +115,83 @@ class Cookie {
     this.partitioned = false,
   });
 
+  /// The cookie name.
+  ///
+  /// When serialized, this must be a valid RFC 6265 token. Empty names and
+  /// names containing separators such as `;`, `,`, or `=` are rejected by
+  /// [serialize].
   final String name;
+
+  /// The cookie value before serialization encoding.
+  ///
+  /// By default, [serialize] applies [Uri.encodeComponent] to this value and
+  /// [parse] or [fromString] applies [Uri.decodeComponent] when a percent escape
+  /// is present. Pass a custom [CookieCodec] to those methods to use a different
+  /// wire encoding.
   final String value;
+
+  /// The absolute expiration time for the `Expires` attribute.
+  ///
+  /// This value is serialized as an HTTP date. When a cookie also has [maxAge],
+  /// [StoredCookie] gives `Max-Age` precedence while computing [StoredCookie.expiresAt].
   final DateTime? expires;
+
+  /// The raw `Domain` attribute value.
+  ///
+  /// This value is not normalized by [Cookie]. [StoredCookie.fromCookie]
+  /// lowercases it, removes a leading dot, and validates it against the request
+  /// host.
   final String? domain;
+
+  /// Whether the `HttpOnly` flag is present.
+  ///
+  /// A cookie with this flag is intended for HTTP request handling and not for
+  /// client-side scripts. The flag only affects serialization; enforcement is a
+  /// user-agent concern.
   final bool httpOnly;
+
+  /// The relative expiration duration for the `Max-Age` attribute.
+  ///
+  /// The value is serialized in whole seconds using [Duration.inSeconds].
+  /// [StoredCookie] treats zero or negative durations as already expired.
   final Duration? maxAge;
+
+  /// The raw `Path` attribute value.
+  ///
+  /// [serialize] rejects non-empty path values that contain control characters
+  /// or `;`. [StoredCookie.fromCookie] computes a default path when the value is
+  /// omitted, empty, or does not start with `/`.
   final String? path;
+
+  /// The `Priority` attribute value.
   final CookiePriority? priority;
+
+  /// The `SameSite` attribute value.
+  ///
+  /// [CookieSameSite.none] requires [secure] to be true when the cookie is
+  /// serialized.
   final CookieSameSite? sameSite;
+
+  /// Whether the `Secure` flag is present.
+  ///
+  /// [StoredCookie] only sends secure cookies to `https` URIs and rejects secure
+  /// cookies received from non-HTTPS request URIs.
   final bool secure;
+
+  /// Whether the `Partitioned` flag is present.
+  ///
+  /// Partitioned cookies must also be [secure] when serialized.
   final bool partitioned;
 
+  /// Creates a copy with selected fields replaced.
+  ///
+  /// Omitted parameters keep their current value. Nullable `Set-Cookie`
+  /// attributes can be removed by including the matching [CookieNullableField]
+  /// in [clear].
+  ///
+  /// It is an error to set and clear the same nullable field in a single call.
+  /// For example, passing both `path: '/'` and
+  /// `clear: {CookieNullableField.path}` throws an [ArgumentError].
   Cookie copyWith({
     String? name,
     String? value,
@@ -127,9 +252,16 @@ class Cookie {
     );
   }
 
-  /// Validates this cookie and returns all error messages.
+  /// Validates this cookie and returns every serialization problem found.
   ///
-  /// Returns an empty list when the cookie can be serialized safely.
+  /// The returned list is empty when [serialize] should be able to produce a
+  /// header value using the same [encode] function. If [encode] throws, the
+  /// error is captured as a validation message and no further value validation
+  /// is attempted.
+  ///
+  /// This method is useful for form-like flows where callers want to report all
+  /// problems at once instead of handling the first exception thrown by
+  /// [serialize].
   List<String> validate({CookieCodec? encode}) {
     final errors = <String>[];
     encode ??= defaultEncode;
@@ -169,6 +301,19 @@ class Cookie {
     return errors;
   }
 
+  /// Serializes this cookie as a `Set-Cookie` header value.
+  ///
+  /// The [value] is encoded before it is written. The default encoder is
+  /// [Uri.encodeComponent].
+  ///
+  /// Throws an [ArgumentError] when [name], [path], or [domain] contains
+  /// characters that cannot be serialized. Throws a [StateError] when the
+  /// encoded value is invalid, when [sameSite] is [CookieSameSite.none] without
+  /// [secure], or when [partitioned] is true without [secure].
+  ///
+  /// See also:
+  ///
+  ///  * [validate], which reports serialization problems without throwing.
   String serialize({CookieCodec? encode}) {
     encode ??= defaultEncode;
 
@@ -256,6 +401,19 @@ class Cookie {
   @override
   String toString() => serialize();
 
+  /// Parses a single `Set-Cookie` header value.
+  ///
+  /// The header must start with a `name=value` pair. Recognized attributes are
+  /// applied to the returned [Cookie], and unknown attributes are ignored.
+  /// Invalid `Expires`, `Max-Age`, `SameSite`, and `Priority` values are ignored
+  /// rather than causing the entire parse to fail.
+  ///
+  /// Explicit false-like flag values (`false`, `0`, and `?0`) disable
+  /// `Secure`, `HttpOnly`, and `Partitioned`; any other flag value enables the
+  /// flag. Quoted cookie values are unwrapped before [decode] is applied.
+  ///
+  /// Throws an [ArgumentError] if [setCookie] is empty, does not start with a
+  /// `name=value` pair, or has an empty cookie name.
   factory Cookie.fromString(String setCookie, {CookieCodec? decode}) {
     decode = (decode ?? defaultDecode).tryRun;
     final parts = setCookie
@@ -350,6 +508,15 @@ class Cookie {
     return cookie;
   }
 
+  /// Parses a `Cookie` request header into name-value pairs.
+  ///
+  /// Malformed segments and empty names are ignored. If a name appears more
+  /// than once, the first parsed value is kept, matching the usual server-side
+  /// behavior for duplicate cookie names.
+  ///
+  /// The optional [filter] is evaluated after the name has been trimmed and
+  /// before the value is decoded. If [decode] throws for a value, the original
+  /// value is kept.
   static Map<String, String> parse(
     String cookies, {
     CookieCodec? decode,
@@ -394,6 +561,13 @@ class Cookie {
     return result;
   }
 
+  /// Splits a combined `Set-Cookie` header value into individual values.
+  ///
+  /// HTTP clients and proxies sometimes expose multiple `Set-Cookie` headers as
+  /// one comma-separated string. A plain `split(',')` is incorrect because
+  /// `Expires` dates and quoted values may contain commas. This method only
+  /// treats a comma as a separator when it is followed by the start of another
+  /// cookie pair.
   static List<String> splitSetCookie(String cookies) {
     final result = <String>[];
     int pos = 0;

--- a/lib/src/cookie_jar.dart
+++ b/lib/src/cookie_jar.dart
@@ -3,11 +3,20 @@ import 'cookie_key.dart';
 import 'stored_cookie.dart';
 import 'types.dart';
 
-/// RFC cookie-store policy that is independent from storage.
+/// Stateless policy operations used by [CookieJar].
+///
+/// The policy knows how to normalize `Set-Cookie` values, test request matches,
+/// sort cookies for a request header, and serialize stored cookies. It does not
+/// own persistence; [CookieStore] is responsible for loading and saving
+/// [StoredCookie] objects.
 final class CookiePolicy {
+  /// Creates a stateless cookie policy.
   const CookiePolicy();
 
-  /// Parses and normalizes a Set-Cookie value received for [requestUri].
+  /// Parses and normalizes a `Set-Cookie` value received for [requestUri].
+  ///
+  /// This is the policy-level entry point used by [CookieJar.save]. It applies
+  /// the request-scoped checks from [StoredCookie.fromSetCookie].
   StoredCookie normalizeSetCookie(
     String setCookie, {
     required Uri requestUri,
@@ -23,6 +32,10 @@ final class CookiePolicy {
   }
 
   /// Normalizes [cookie] as if it was received for [requestUri].
+  ///
+  /// This is useful when callers already have parsed [Cookie] objects and want
+  /// the same matching state that would have been produced from a `Set-Cookie`
+  /// header.
   StoredCookie normalizeCookie(
     Cookie cookie, {
     required Uri requestUri,
@@ -36,14 +49,18 @@ final class CookiePolicy {
   }
 
   /// Whether [cookie] should be sent to [uri] at [now].
+  ///
+  /// This delegates to [StoredCookie.matches] and therefore applies expiry,
+  /// host-only/domain, path, and secure matching.
   bool matches(StoredCookie cookie, Uri uri, DateTime now) {
     return cookie.matches(uri, now: now);
   }
 
-  /// Sorts cookies for a Cookie request header.
+  /// Sorts cookies for a `Cookie` request header.
   ///
   /// Longer paths are ordered first. Cookies with the same path length are
-  /// ordered by earlier creation time.
+  /// ordered by earlier [StoredCookie.creationTime]. This matches the ordering
+  /// used by [CookieJar.header].
   List<StoredCookie> sortForHeader(Iterable<StoredCookie> cookies) {
     return cookies.toList()
       ..sort((a, b) {
@@ -56,14 +73,19 @@ final class CookiePolicy {
       });
   }
 
-  /// Serializes one stored cookie as a request Cookie header pair.
+  /// Serializes one stored cookie as a request `Cookie` header pair.
+  ///
+  /// Only the name and value are included. `Set-Cookie` attributes are storage
+  /// metadata and are not emitted in request headers.
   String toRequestCookie(StoredCookie cookie, {CookieCodec? encode}) {
     return cookie.toRequestCookie(encode: encode);
   }
 
-  /// Serializes stored cookies as a single Cookie request header value.
+  /// Serializes stored cookies as a single `Cookie` request header value.
   ///
-  /// Set [sort] to false when [cookies] are already in header order.
+  /// Set [sort] to false when [cookies] are already in header order. The result
+  /// is an empty string when [cookies] is empty; [CookieJar.header] wraps this
+  /// behavior and returns null for the no-match case.
   String toRequestHeaderValue(
     Iterable<StoredCookie> cookies, {
     CookieCodec? encode,
@@ -76,23 +98,39 @@ final class CookiePolicy {
   }
 }
 
-/// Pluggable persistence boundary for stored cookies.
+/// Pluggable persistence boundary for [CookieJar].
+///
+/// A store does not need to implement matching rules. It should return cookies
+/// that may match or may be replaced for a URI, and let [CookieJar] apply
+/// expiry, domain, path, secure, and sorting policy.
 abstract interface class CookieStore {
-  /// Loads cookies that may match or be replaced by cookies from [uri].
+  /// Loads cookies that may match [uri] or may be replaced by cookies from it.
+  ///
+  /// Implementations may return a broad candidate set. [CookieJar] filters the
+  /// result before sending a request header.
   Future<Iterable<StoredCookie>> loadCandidates(Uri uri);
 
   /// Inserts or replaces [cookie] by name, domain, path, and host-only state.
+  ///
+  /// [CookieKey.fromStoredCookie] defines the identity used by the default
+  /// store.
   Future<void> upsert(StoredCookie cookie);
 
   /// Deletes the cookie identified by [key].
   Future<void> delete(CookieKey key);
 
-  /// Removes every cookie.
+  /// Removes every cookie held by this store.
   Future<void> clear();
 }
 
 /// Dependency-light in-memory cookie storage.
+///
+/// This store is suitable for tests, command-line tools, and short-lived
+/// clients. It does not persist across process restarts.
 final class MemoryCookieStore implements CookieStore {
+  /// Creates an empty in-memory cookie store.
+  MemoryCookieStore();
+
   final Map<CookieKey, StoredCookie> _cookies = <CookieKey, StoredCookie>{};
 
   @override
@@ -116,8 +154,32 @@ final class MemoryCookieStore implements CookieStore {
   }
 }
 
-/// Cookie jar that combines RFC policy with a pluggable store.
+/// Client-side cookie jar with pluggable persistence.
+///
+/// A [CookieJar] accepts `Set-Cookie` values received from response URIs and
+/// later builds the `Cookie` request header for another URI. It combines
+/// [CookiePolicy] with a [CookieStore] so that matching rules stay independent
+/// from storage.
+///
+/// The jar removes expired cookies as they are encountered, preserves creation
+/// time when a cookie is replaced, and ignores insecure attempts to overwrite an
+/// existing secure cookie when the domains and paths overlap.
+///
+/// ```dart
+/// final jar = CookieJar();
+/// await jar.save(
+///   Uri.parse('https://example.com/login'),
+///   ['sid=abc; Path=/; HttpOnly'],
+/// );
+///
+/// final header = await jar.header(
+///   Uri.parse('https://example.com/profile'),
+/// );
+/// ```
 final class CookieJar {
+  /// Creates a cookie jar backed by [store] and [policy].
+  ///
+  /// When [store] is omitted, a new [MemoryCookieStore] is used.
   CookieJar({
     CookieStore? store,
     this.policy = const CookiePolicy(),
@@ -129,7 +191,14 @@ final class CookieJar {
   /// Policy used for normalization, matching, sorting, and serialization.
   final CookiePolicy policy;
 
-  /// Saves received Set-Cookie header values for [uri].
+  /// Saves received `Set-Cookie` header values for [uri].
+  ///
+  /// Each value is parsed, normalized against [uri], and inserted into [store].
+  /// A cookie with the same name, domain, path, and host-only state replaces the
+  /// previous value while preserving its creation time.
+  ///
+  /// Expired cookies are deleted instead of stored. Invalid domain, secure, or
+  /// prefix constraints throw [ArgumentError] through [policy].
   Future<void> save(
     Uri uri,
     Iterable<String> setCookieValues, {
@@ -152,6 +221,10 @@ final class CookieJar {
   }
 
   /// Saves parsed cookies as if they were received for [uri].
+  ///
+  /// This is the parsed-object equivalent of [save]. It is useful when a caller
+  /// has already constructed [Cookie] instances but still wants jar policy for
+  /// normalization, replacement, expiry, and secure-overlay checks.
   Future<void> saveCookies(
     Uri uri,
     Iterable<Cookie> cookies, {
@@ -172,6 +245,10 @@ final class CookieJar {
   }
 
   /// Loads stored cookies that match [uri].
+  ///
+  /// Expired cookies found in [store] are deleted. Matching cookies have their
+  /// [StoredCookie.lastAccessTime] updated to [now] and are returned in request
+  /// header order.
   Future<List<StoredCookie>> loadStored(Uri uri, {DateTime? now}) async {
     final nowUtc = (now ?? DateTime.now()).toUtc();
     final matched = <StoredCookie>[];
@@ -194,15 +271,20 @@ final class CookieJar {
   }
 
   /// Loads parsed cookies that match [uri].
+  ///
+  /// This is a convenience wrapper around [loadStored] for callers that do not
+  /// need storage metadata such as domain, path, or expiry.
   Future<List<Cookie>> load(Uri uri, {DateTime? now}) async {
     return [
       for (final stored in await loadStored(uri, now: now)) stored.cookie,
     ];
   }
 
-  /// Builds the Cookie request header value for [uri].
+  /// Builds the `Cookie` request header value for [uri].
   ///
-  /// Returns null when no stored cookie matches.
+  /// Returns null when no stored cookie matches. The returned string is already
+  /// sorted using [CookiePolicy.sortForHeader] and can be assigned directly to a
+  /// request's `Cookie` header.
   Future<String?> header(
     Uri uri, {
     DateTime? now,

--- a/lib/src/cookie_key.dart
+++ b/lib/src/cookie_key.dart
@@ -1,7 +1,19 @@
+/// @docImport 'cookie_jar.dart';
+library;
+
 import 'stored_cookie.dart';
 
-/// Identity used to replace and delete cookies in a store.
+/// Identity used to replace and delete stored cookies.
+///
+/// A cookie is not identified by name alone. User agents can store multiple
+/// cookies with the same name when they differ by domain, path, or host-only
+/// state. [CookieStore] implementations should use this key, or an equivalent
+/// tuple, when replacing and deleting cookies.
 final class CookieKey {
+  /// Creates a cookie identity from normalized cookie fields.
+  ///
+  /// The values are expected to match the corresponding fields on a
+  /// [StoredCookie].
   const CookieKey({
     required this.name,
     required this.domain,
@@ -9,19 +21,22 @@ final class CookieKey {
     required this.hostOnly,
   });
 
-  /// Cookie name.
+  /// The cookie name.
   final String name;
 
-  /// Normalized domain used for matching.
+  /// The normalized domain used for matching.
   final String domain;
 
-  /// Effective path used for matching.
+  /// The effective path used for matching.
   final String path;
 
   /// Whether the cookie is scoped to one host.
   final bool hostOnly;
 
   /// Creates a key for [cookie].
+  ///
+  /// This is the identity used by [MemoryCookieStore] and by [CookieJar] when
+  /// deciding whether a new cookie replaces an existing one.
   factory CookieKey.fromStoredCookie(StoredCookie cookie) {
     return CookieKey(
       name: cookie.cookie.name,

--- a/lib/src/stored_cookie.dart
+++ b/lib/src/stored_cookie.dart
@@ -1,12 +1,45 @@
+/// @docImport 'cookie_jar.dart';
+/// @docImport 'cookie_key.dart';
+library;
+
 import 'cookie.dart';
 import 'types.dart';
 
 /// A normalized cookie entry for client-side request matching.
 ///
-/// [Cookie] represents the parsed Set-Cookie value. [StoredCookie] adds the
-/// user-agent state needed to decide whether that cookie should be sent with a
-/// later request.
+/// [Cookie] stores the name, value, and optional `Set-Cookie` attributes as
+/// they appear on the wire. [StoredCookie] adds the user-agent state needed to
+/// decide whether the cookie should be sent with a later request: normalized
+/// domain and path values, host-only state, expiry, creation time, and last
+/// access time.
+///
+/// Most callers should use [CookieJar] instead of constructing this class
+/// directly. Use [StoredCookie] when implementing custom storage or when a
+/// lower-level policy decision needs to be tested explicitly.
+///
+/// ```dart
+/// final stored = StoredCookie.fromSetCookie(
+///   'sid=abc; Path=/; HttpOnly',
+///   requestUri: Uri.parse('https://example.com/login'),
+/// );
+///
+/// final matches = stored.matches(
+///   Uri.parse('https://example.com/profile'),
+/// );
+/// ```
+///
+/// See also:
+///
+///  * [CookieJar], which stores and matches cookies for request URIs.
+///  * [CookiePolicy], which exposes normalization and matching operations
+///    without owning storage.
 final class StoredCookie {
+  /// Creates normalized cookie state for request matching.
+  ///
+  /// The constructor trusts that [domain], [path], [hostOnly], and [expiresAt]
+  /// have already been normalized consistently with [cookie]. Prefer
+  /// [StoredCookie.fromCookie] or [StoredCookie.fromSetCookie] when accepting
+  /// data from HTTP headers.
   const StoredCookie({
     required this.cookie,
     required this.domain,
@@ -17,30 +50,57 @@ final class StoredCookie {
     required this.lastAccessTime,
   });
 
-  /// The parsed cookie with normalized Domain and Path attributes.
+  /// The parsed cookie with normalized `Domain` and `Path` attributes.
+  ///
+  /// For host-only cookies, [Cookie.domain] is cleared and the effective host is
+  /// stored in [domain]. For domain cookies, [Cookie.domain] is normalized to the
+  /// same value as [domain].
   final Cookie cookie;
 
   /// The normalized domain used for request matching.
+  ///
+  /// This is lowercased and has any trailing dot removed from the request host.
+  /// Domain attributes also have a leading dot removed.
   final String domain;
 
   /// The effective path used for request matching.
+  ///
+  /// If the source cookie omits `Path`, uses an empty path, or uses a value that
+  /// does not start with `/`, [StoredCookie.fromCookie] derives the default path
+  /// from the request URI.
   final String path;
 
-  /// Whether the cookie omitted a Domain attribute and is bound to one host.
+  /// Whether the cookie omitted a `Domain` attribute and is bound to one host.
+  ///
+  /// Host-only cookies match exactly [domain] and do not match subdomains.
   final bool hostOnly;
 
-  /// The absolute expiry time after applying Max-Age precedence.
+  /// The absolute expiry time after applying `Max-Age` precedence.
   ///
-  /// A null value represents a session cookie.
+  /// A null value represents a session cookie. A zero or negative `Max-Age`
+  /// value produces an expiry time at or before [creationTime].
   final DateTime? expiresAt;
 
   /// When this cookie was first created in the store.
+  ///
+  /// [CookieJar] preserves this value when a cookie is replaced by another
+  /// cookie with the same [CookieKey].
   final DateTime creationTime;
 
   /// When this cookie was last selected for a request.
+  ///
+  /// [CookieJar.loadStored] updates this value for cookies that match the
+  /// requested URI.
   final DateTime lastAccessTime;
 
-  /// Parses and normalizes a Set-Cookie value received for [requestUri].
+  /// Parses and normalizes a `Set-Cookie` value received for [requestUri].
+  ///
+  /// The [requestUri] must include a host. Secure cookies must be received from
+  /// an `https` URI. Domain attributes must domain-match the request host, and
+  /// `__Secure-` or `__Host-` prefixes are validated while normalizing.
+  ///
+  /// Throws an [ArgumentError] when the header cannot be parsed or when the
+  /// cookie is not valid for [requestUri].
   factory StoredCookie.fromSetCookie(
     String setCookie, {
     required Uri requestUri,
@@ -55,6 +115,10 @@ final class StoredCookie {
   }
 
   /// Normalizes [cookie] as if it was received for [requestUri].
+  ///
+  /// This applies the same request-scoped rules as [StoredCookie.fromSetCookie],
+  /// but starts from an already parsed [Cookie]. The returned cookie has an
+  /// effective domain, path, expiry, creation time, and last access time.
   factory StoredCookie.fromCookie(
     Cookie cookie, {
     required Uri requestUri,
@@ -104,6 +168,10 @@ final class StoredCookie {
   }
 
   /// Creates a copy with selected fields replaced.
+  ///
+  /// Omitted parameters keep their current value. Set [clearExpiresAt] to true
+  /// to turn the copy into a session cookie. Passing both [expiresAt] and
+  /// [clearExpiresAt] is an [ArgumentError].
   StoredCookie copyWith({
     Cookie? cookie,
     String? domain,
@@ -134,12 +202,20 @@ final class StoredCookie {
   }
 
   /// Whether this cookie is expired at [now].
+  ///
+  /// The comparison uses UTC. Session cookies, represented by a null
+  /// [expiresAt], are never expired by this method.
   bool isExpired(DateTime now) {
     final expiresAt = this.expiresAt;
     return expiresAt != null && !expiresAt.isAfter(now.toUtc());
   }
 
   /// Whether this cookie should be sent with a request to [uri].
+  ///
+  /// The URI must include a host. Host-only cookies require an exact host
+  /// match. Domain cookies also match subdomains, except for IP-address hosts.
+  /// The request path must path-match [path], and secure cookies only match
+  /// `https` URIs.
   ///
   /// If [now] is supplied, expired cookies do not match.
   bool matches(Uri uri, {DateTime? now}) {
@@ -168,7 +244,11 @@ final class StoredCookie {
     return true;
   }
 
-  /// Serializes the cookie as a Cookie request header pair.
+  /// Serializes the cookie as a `Cookie` request header pair.
+  ///
+  /// Only the cookie [Cookie.name] and [Cookie.value] are included. Attributes
+  /// such as `Path`, `Domain`, `HttpOnly`, and `Secure` are never written to a
+  /// request `Cookie` header.
   String toRequestCookie({CookieCodec? encode}) {
     return Cookie(cookie.name, cookie.value).serialize(encode: encode);
   }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,1 +1,7 @@
+/// Function used to encode or decode cookie values.
+///
+/// The default encoder uses [Uri.encodeComponent], and the default decoder uses
+/// [Uri.decodeComponent] when the value contains a percent escape. Custom
+/// codecs are useful for applications that already store cookie-safe values or
+/// that use a different escaping scheme.
 typedef CookieCodec = String Function(String value);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ocookie
-description: Cookie and Set-Cookie parser and serializer.
+description: HTTP Cookie and Set-Cookie parser, serializer, and cookie jar primitives for Dart and Flutter clients.
 repository: https://github.com/odroe/ocookie
 funding:
   - https://github.com/sponsors/medz


### PR DESCRIPTION
## Summary

- Expand the package description so pub.dev accepts the `pubspec.yaml` metadata.
- Add a runnable `example/main.dart` so pub.dev can render an Example tab.
- Restructure the README around common cookie tasks and the API to use for each one.
- Rewrite public API dartdoc in a Flutter SDK style with semantics, constraints, examples, and cross-API references.

## Validation

- `dart analyze`
- `dart test`
- `dart doc --output <tmp>`
- `dart pub global run pana <tmp copy>`: `160/160`, `80/80` documented API elements
- `dart pub publish --dry-run`: 0 warnings

No linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with clearer guidance, API selection table, and dedicated sections for common cookie operations.
  * Expanded API documentation across all public modules with detailed behavior descriptions.
  * Added runnable example demonstrating end-to-end cookie parsing, serialization, and jar usage.
  * Updated package description to clarify HTTP cookie handling and jar capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->